### PR TITLE
Leader election

### DIFF
--- a/src/app_logic.py
+++ b/src/app_logic.py
@@ -11,11 +11,13 @@ SHARED_DIR = "shared"
 NODE_PREFIX = "node_"
 
 class CounterApp(Thread):
-    def __init__(self):
+    def __init__(self, leader_manager):
         Thread.__init__(self)
         self.quit = False
         self._my_ip = None
         self.nodes = []
+        self.discovery_ready = False
+        self.leader_manager = leader_manager
 
     def get_my_ip(self):
         if self._my_ip:
@@ -83,6 +85,7 @@ class CounterApp(Thread):
                 except:
                     pass
         self.nodes = working_nodes
+        self.discovery_ready = True
 
         print("Discovery ready for {}, nodes: {}!".format(self.get_my_ip(), self.nodes))
 
@@ -90,6 +93,9 @@ class CounterApp(Thread):
         print("CounterApp {} starting...".format(self.get_my_ip()))
 
         self.discovery(3000)
+
+        self.leader_manager.hold_election(self.get_my_ip(), self.nodes)
+        print("Node {}'s leader: {}".format(self.get_my_ip(), self.leader_manager.leader_ip))
 
         while not self.quit:
             time.sleep(1)

--- a/src/leader.py
+++ b/src/leader.py
@@ -1,0 +1,67 @@
+import time
+import urllib
+from concurrent.futures import ThreadPoolExecutor
+
+class LeaderManager:
+    def __init__(self, election_window, message_timeout):
+        self.leader_ip = None
+        self._election_window = election_window
+        self._message_timeout = message_timeout
+        self._last_election = 0
+
+    def _in_election(self):
+        return self._last_election + self._election_window > time.time()
+
+    def _mark_started(self):
+        self._last_election = time.time()
+
+    def victory(self, leader_ip):
+        self.leader_ip = leader_ip
+        # self._mark_started()
+
+    def _broadcast_election(self, own_ip, other_nodes):
+        larger_nodes = list(filter(lambda x: x > own_ip, other_nodes))
+
+        def node_answers(target_node):
+            url = f"http://{target_node}:8000/election"
+            try:
+                urllib.request.urlopen(
+                    url, timeout=self._message_timeout)
+                return True
+            except Exception as ex:
+                print(f"Node {own_ip} failed broadcasting election to {target_node}: {ex}")
+                return False
+
+        with ThreadPoolExecutor(max(1, len(larger_nodes))) as executor:
+            is_leader = True not in executor.map(node_answers, larger_nodes)
+            return is_leader
+
+    def _broadcast_victory(self, own_ip, other_nodes):
+        self.victory(own_ip)
+
+        def f(target_node):
+            url = f"http://{target_node}:8000/victory"
+            try:
+                data = urllib.parse.urlencode({"leader_ip": own_ip})
+                data = data.encode('ascii')
+                urllib.request.urlopen(
+                    url, data, timeout=self._message_timeout)
+            except Exception as ex:
+                print(f"Node {own_ip} failed broadcasting victory to {target_node}: {ex}")
+
+        with ThreadPoolExecutor(max(1, len(other_nodes))) as executor:
+            executor.map(f, other_nodes)
+
+    def _hold_election(self, own_ip, other_nodes):
+        if self._in_election():
+            return
+        self._mark_started()
+        # TODO should this be here?
+        # self.leader_ip = None
+        if self._broadcast_election(own_ip, other_nodes):
+            self._broadcast_victory(own_ip, other_nodes)
+
+    def hold_election(self, own_ip, other_nodes, wait=True):
+        self._hold_election(own_ip, other_nodes)
+        if wait:
+            time.sleep(self._election_window)

--- a/src/main.py
+++ b/src/main.py
@@ -26,7 +26,7 @@ def status():
 def die():
     counter_app.quit = True
 
-@app.route("/election", methods=["GET"])
+@app.route("/election", methods=["POST"])
 def election():
     if counter_app.discovery_ready:
         counter_app.leader_manager.hold_election(
@@ -38,7 +38,7 @@ def election():
 
 @app.route("/victory", methods=["POST"])
 def victory():
-    counter_app.leader_manager.victory(request.form["leader_ip"])
+    counter_app.leader_manager.leader_ip = request.form["leader_ip"]
     return "OK"
 
 if __name__ == "__main__":

--- a/src/main.py
+++ b/src/main.py
@@ -4,9 +4,10 @@ from flask import Flask, render_template, request
 from flask.json import jsonify
 import words_counting
 from app_logic import CounterApp
+import leader
 
 app = Flask(__name__)
-counter_app = CounterApp()
+counter_app = CounterApp(leader.LeaderManager(3, 0.1))
 
 @app.route("/", methods=['GET', 'POST'])
 def index():
@@ -25,7 +26,21 @@ def status():
 def die():
     counter_app.quit = True
 
+@app.route("/election", methods=["GET"])
+def election():
+    if counter_app.discovery_ready:
+        counter_app.leader_manager.hold_election(
+            counter_app.get_my_ip(),
+            counter_app.nodes,
+            False
+        )
+    return "OK"
+
+@app.route("/victory", methods=["POST"])
+def victory():
+    counter_app.leader_manager.victory(request.form["leader_ip"])
+    return "OK"
+
 if __name__ == "__main__":
     counter_app.start()
     app.run(debug=False, port=8000, host="0.0.0.0")
-


### PR DESCRIPTION
### Distinguishing election rounds
In the bully algorithm it it necessary to determine if a node has
already participated in the election. This is done in the code by
setting the `election_window` parameter and calling `_in_election` and
`_mark_started` functions.

### Node discovery not finished
Currently if a node receives an election query when it is still discovering
other nodes, it will answer the query but will not broadcast any election
messages. This prevents nodes from falsely deducing they are the leaders.

### Concurrency
The modified variables common to thread in `LeaderManager` are
- `leader_ip`
- `_last_election`

Both of these are only modified with atomic operations.
Should be ok?

### Uncertain implementation details
Should we set `leader_ip = None` when the node receives election message?
Perhaps not since if we don't reset the `leader_ip`, nodes that used
to be down but now are up again can initiate election without
disturbing other nodes. However, it might be useful to have a
mechanism to know if an election didn't find a leader when calling
`hold_election`.

Should the victory message mark the election as started?
No need? The point of marking an election started seems to mainly
be to prevent sending unnecessary election broadcasts.

### Example scenarios:

The leader election can always fail if the messages cannot be transferred
reliably. In worst case, we will have two separate networks of nodes
each with their own leader.

`hold_election` called, all previous elections have expired
- Case 1: Starting node is the largest alive
  - Sends victory to everyone
  - Case 1.1. Another node detects leader failure before receiving the
	new leader.
	- If a new leader election is started, no new victory messages
	  can be sent because the node with the largest ip is still in
	  the "election running" mode. Thus, in worst case we will just
	  have extra messages being sent.
  - Case 1.2. All other nodes receive new leader
    - Everything OK
  - Case 1.3. Some other nodes don't receive the new leader
    - Might initiate leader election later. As long as the current
	  leader doesn't fail, this shouldn't affect anything.
- Case 2: Starting node not the largest alive
  - broadcasts election to the larger nodes
  - Case 2.1. Messages never reach the larger nodes
	- Incorrectly sends victory to everyone
  - Case 2.2. Multiple larger nodes answer
	- Largest of these will be the leader.
	- Each of the larger nodes will mark the election started
	  so they will broadcast at most N election messages each.

`hold_election` called, some previous election still not expired
- Case 1: The new leader's election has expired
  - Everything OK
- Case 2: The new leader's election has not expired
  - No new leader will be elected
  - NOTE: the election will not be marked started again for the new
    leader. Therefore at some point after subsequent election calls
    the leader's election will expire and it will broadcast victory.
